### PR TITLE
(BKR-1481) Rewrite beaker-vmware to use shared .fog parsing

### DIFF
--- a/lib/beaker/hypervisor/vsphere_helper.rb
+++ b/lib/beaker/hypervisor/vsphere_helper.rb
@@ -12,25 +12,12 @@ class VsphereHelper
   end
 
   def self.load_config(dot_fog = '.fog')
-    # support Fog/Cloud Provisioner layout
-    # (ie, someplace besides my made up conf)
-    vsphere_credentials = nil
-    if File.exists?( dot_fog )
-      vsphere_credentials = load_fog_credentials(dot_fog)
-    else
-      raise ArgumentError, ".fog file '#{dot_fog}' does not exist"
-    end
-
-    return vsphere_credentials
-  end
-
-  def self.load_fog_credentials(dot_fog = '.fog')
-    vInfo = YAML.load_file( dot_fog )
+    default = parse_fog_file(dot_fog)
 
     vsphere_credentials = {}
-    vsphere_credentials[:server] = vInfo[:default][:vsphere_server]
-    vsphere_credentials[:user]   = vInfo[:default][:vsphere_username]
-    vsphere_credentials[:pass]   = vInfo[:default][:vsphere_password]
+    vsphere_credentials[:server] = default[:vsphere_server]
+    vsphere_credentials[:user]   = default[:vsphere_username]
+    vsphere_credentials[:pass]   = default[:vsphere_password]
 
     return vsphere_credentials
   end

--- a/lib/beaker/hypervisor/vsphere_helper.rb
+++ b/lib/beaker/hypervisor/vsphere_helper.rb
@@ -12,7 +12,7 @@ class VsphereHelper
   end
 
   def self.load_config(dot_fog = '.fog')
-    default = parse_fog_file(dot_fog)
+    default = get_fog_credentials(dot_fog)
 
     vsphere_credentials = {}
     vsphere_credentials[:server] = default[:vsphere_server]

--- a/spec/beaker/hypervisor/vsphere_helper_spec.rb
+++ b/spec/beaker/hypervisor/vsphere_helper_spec.rb
@@ -22,7 +22,7 @@ module Beaker
     describe "#load_config" do
 
       it 'can load a .fog file' do
-        allow( File ).to receive( :exists? ).and_return( true )
+        allow( File ).to receive( :exist? ).and_return( true )
         allow( YAML ).to receive( :load_file ).and_return( fog_file_contents )
 
         expect( VsphereHelper.load_config ).to be === vInfo
@@ -30,7 +30,7 @@ module Beaker
       end
 
       it 'raises an error when the .fog file is missing' do
-        allow( File ).to receive( :exists? ).and_return( false )
+        allow( File ).to receive( :exist? ).and_return( false )
 
         expect{ VsphereHelper.load_config }.to raise_error( ArgumentError )
 

--- a/vsphere.md
+++ b/vsphere.md
@@ -3,34 +3,37 @@ that beaker will use to get Systems Under Test (SUTs) from any vSphere
 infrastructure that you might have.
 
 **Note** that if you're a puppet-internal user, or an external user that is
-using the vmpooler hypervisor, please refer to our [vmpooler doc](https://github.com/puppetlabs/beaker-vmpooler)
-for info, as it can be different than the information here. 
+using the vmpooler hypervisor, please refer to our [vmpooler doc](https://github.com/puppetlabs/beaker-vmpooler). beaker-vmpooler is now completely independent from beaker-vmware.
 
 The harness can use vms and snapshots that live within vSphere as well.
 To do this create a `~/.fog` file with your vSphere credentials:
 
-### example .fog file ###
+~~~yaml
+default:
+  vsphere_server: 'vsphere.example.com'
+  vsphere_username: 'joe'
+  vsphere_password: 'MyP@$$w0rd'
+~~~
 
-    :default:
-      :vsphere_server: 'vsphere.example.com'
-      :vsphere_username: 'joe'
-      :vsphere_password: 'MyP@$$w0rd'
+This file follows the conventions used by Cloud Provisioner and Fog. Note:
 
-These follow the conventions used by Cloud Provisioner and Fog.
+- You *may* use Strings or Ruby Symbols (e.g. `:default`) for keys, as both are formally supported by both Fog and Beaker, however for maximum interoprability it is recommended to use Strings.
+- Your fog credential file location may be specified in the 'CONFIG' section using the 'dot_fog' setting. It can also be overridden by setting `ENV["FOG_RC"]` on the beaker coordinator.
+- Fog supports multiple configuration sections (called "providers") in a single file. Normally you'll just use `default`, but you can also specify other providers. beaker-vmware doesn't select these, but you can specify them by setting `ENV["FOG_CREDENTIAL"]` on the beaker coordinator.
 
->Note: Your fog credential file location may be specified in the 'CONFIG' section using the 'dot_fog' setting
+# Hypervisors
 
 There are two possible `hypervisor` hypervisor-types to use for vSphere testing, `vsphere` and `vcloud`.
 
-### `hypervisor: vsphere`
+## `hypervisor: vsphere`
 This option locates an existing static VM, optionally reverts it to a pre-existing snapshot, and runs tests on it.
 
-### `hypervisor: vcloud`
+## `hypervisor: vcloud`
 This option clones a new VM from a pre-existing template, runs tests on the newly-provisioned clone, then deletes the clone once testing completes.
 
 The `vcloud` option requires a slightly-modified test configuration file, specifying both the target template as well as three additional parameters in the 'CONFIG' section ('datastore', 'datacenter', and 'folder').  Optionally, a resourcepool may be specified via the 'resourcepool' setting in the 'CONFIG' section.  Template can be expressed in the 'HOSTS' section, or you can set the template to be used via the `BEAKER_vcloud_template` environment variable.
 
-#### example vcloud hosts file ###
+#### Example vcloud hosts file
     HOSTS:
       master-vm:
         roles:


### PR DESCRIPTION
Depends on puppetlabs/beaker#1526. Will fail test until that is merged/released.