### PR TITLE
(WIP) (BKR-1507) load_config to allow multiple vcenters

### DIFF
--- a/lib/beaker/hypervisor/vsphere_helper.rb
+++ b/lib/beaker/hypervisor/vsphere_helper.rb
@@ -22,6 +22,19 @@ class VsphereHelper
     return vsphere_credentials
   end
 
+  # New method (so as not to conflict with any existing vshere cred retrieval)
+  # Return credentials associated with specific vcenter_instance
+  def self.get_vsphere_creds(dot_fog = '.fog', credential_group = :default)
+    fog_credentials = get_fog_credentials(dot_fog, credential_group)
+
+    vsphere_credentials = {}
+    vsphere_credentials[:server] = fog_credentials[:vsphere_server]
+    vsphere_credentials[:user]   = fog_credentials[:vsphere_username]
+    vsphere_credentials[:pass]   = fog_credentials[:vsphere_password]
+
+    return vsphere_credentials
+  end
+
   def find_snapshot vm, snapname
     if vm.snapshot
       search_child_snaps vm.snapshot.rootSnapshotList, snapname
@@ -188,4 +201,3 @@ class VsphereHelper
     @connection.close
   end
 end
-

--- a/spec/beaker/hypervisor/vsphere_helper_spec.rb
+++ b/spec/beaker/hypervisor/vsphere_helper_spec.rb
@@ -36,6 +36,18 @@ module Beaker
 
       end
 
+      it 'Picks up the top-level creds if no instance specified' do
+        # TBD
+      end
+
+      it 'Picks up instance creds if instance specified' do
+        # TBD
+      end
+
+      it 'raises an error if it cant find the instance' do
+        # TBD
+      end
+
     end
 
    describe "#find_snapshot" do


### PR DESCRIPTION
Supplement load_config to handle credentials for multiple vcenter instances
so that we aren't limited to a single set of vcenter credentials.

This is a more aptly named method for the purpose which can be used in
place of the existing method for the remainder of those modules that
grab vsphere creds - once that is done, the load_config method can be
dropped.